### PR TITLE
Feature/add color on job status

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,3 +25,4 @@ rules:
   import/extensions: 'off'
   import/no-dynamic-require: 0
   indent:  ["error", 4, {"SwitchCase": 1}]
+  no-void: off

--- a/.github/workflows/testOnUnitTests.yml
+++ b/.github/workflows/testOnUnitTests.yml
@@ -13,6 +13,7 @@ jobs:
           npm install
           npm test
       - name: Test sample notification
+        if: always()
         uses: ./
         with:
           job_status: ${{ job.status }}

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,14 @@ author: 'EF'
 inputs:
   webhook_url:
     description: 'MS Teams Webhook URL'
+    required: true
   event_id:
     description: 'Github event that triggers the notification'
+  job_status:
+    description: 'Current job status'
+    required: true
+  details:
+    description: 'Additional details or basic compact notification text'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -540,7 +540,7 @@ function notifyTeams(notificationMessage) {
     });
 }
 checkBasicInputsSet();
-if (core.getInput('job_status').toUpperCase() !== constants_1.jobStatus.cancelled.status) {
+if (core.getInput('job_status') !== constants_1.jobStatus.cancelled.status) {
     const eventNotification = parseEventToMessage(readEventPayloadFile(constants_1.githubEventPayloadFile));
     if (eventNotification) {
         notifyTeams(eventNotification);

--- a/dist/index.js
+++ b/dist/index.js
@@ -540,7 +540,7 @@ function notifyTeams(notificationMessage) {
     });
 }
 checkBasicInputsSet();
-if (core.getInput('job_status') !== constants_1.jobStatus.cancelled.status) {
+if (core.getInput('job_status').toLowerCase() !== constants_1.jobStatus.cancelled.status) {
     const eventNotification = parseEventToMessage(readEventPayloadFile(constants_1.githubEventPayloadFile));
     if (eventNotification) {
         notifyTeams(eventNotification);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,18 @@
+import * as core from '@actions/core';
+import { join } from 'path';
+
+export const defaultJsonPath = join(__dirname, '..', 'resources', 'notification.json');
+export const workflow = process.env.GITHUB_WORKFLOW;
+export const repository = process.env.GITHUB_REPOSITORY;
+export const branch = process.env.GITHUB_REF;
+export const githubEventPayloadFile = process.env.GITHUB_EVENT_PATH || defaultJsonPath;
+export const triggerEventName = process.env.GITHUB_EVENT_NAME;
+export const eventName: string = core.getInput('event_id') || triggerEventName || 'event';
+export const status = core.getInput('job_status');
+
+export const jobStatus = {
+    success: { status: 'success', themeColor: '5D985E' },
+    failure: { status: 'failure', themeColor: 'AD362F' },
+    always: { status: 'always', themeColor: '1853DB' },
+    cancelled: { status: 'cancelled', themeColor: 'FB9A5B' }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-unused-vars */
 import * as core from '@actions/core';
-import { join } from 'path';
 import * as fetch from 'node-fetch';
 import { readFileSync } from 'jsonfile';
 import { ValidationError } from 'yup';
@@ -13,15 +12,17 @@ import {
     schemaOnPullRequest,
     schemaOnpush
 } from './eventPayloadSchemaBuilder';
+import {
+    workflow,
+    repository,
+    eventName,
+    branch,
+    githubEventPayloadFile,
+    status,
+    jobStatus
+} from './constants';
 import notificationTemplate from './resources/notification.json';
 
-const defaultJsonPath = join(__dirname, '..', 'resources', 'notification.json');
-const workflow = process.env.GITHUB_WORKFLOW;
-const repository = process.env.GITHUB_REPOSITORY;
-const branch = process.env.GITHUB_REF;
-const githubEventPayloadFile = process.env.GITHUB_EVENT_PATH || defaultJsonPath;
-const triggerEventName = process.env.GITHUB_EVENT_NAME;
-const eventName: string = core.getInput('event_id') || triggerEventName || 'event';
 
 function checkBasicInputsSet() {
     if (!(core.getInput('webhook_url')) || !(core.getInput('job_status'))) {
@@ -96,7 +97,8 @@ function formatRequestBodyData(notificationMessage: NotificationMessage) {
         GITHUB_TRIGGER_EVENT_DETAILS: notificationMessage.details,
         GITHUB_TRIGGER_EVENT: notificationMessage.message,
         GITHUB_EVENT_URL: notificationMessage.url,
-        GITHUB_STATUS: core.getInput('job_status')
+        GITHUB_STATUS: status,
+        THEME_COLOR: jobStatus[status.toLowerCase()].themeColor
     };
 
     return String.Format(JSON.stringify(notificationTemplate), configuration);
@@ -127,7 +129,7 @@ async function notifyTeams(notificationMessage: NotificationMessage) {
 }
 
 checkBasicInputsSet();
-if (core.getInput('job_status').toUpperCase() !== 'CANCELLED') {
+if (core.getInput('job_status').toUpperCase() !== jobStatus.cancelled.status) {
     const eventNotification = parseEventToMessage(readEventPayloadFile(githubEventPayloadFile));
     if (eventNotification) {
         notifyTeams(eventNotification);

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,7 @@ async function notifyTeams(notificationMessage: NotificationMessage) {
 }
 
 checkBasicInputsSet();
-if (core.getInput('job_status') !== jobStatus.cancelled.status) {
+if (core.getInput('job_status').toLowerCase() !== jobStatus.cancelled.status) {
     const eventNotification = parseEventToMessage(readEventPayloadFile(githubEventPayloadFile));
     if (eventNotification) {
         notifyTeams(eventNotification);

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,7 @@ async function notifyTeams(notificationMessage: NotificationMessage) {
 }
 
 checkBasicInputsSet();
-if (core.getInput('job_status').toUpperCase() !== jobStatus.cancelled.status) {
+if (core.getInput('job_status') !== jobStatus.cancelled.status) {
     const eventNotification = parseEventToMessage(readEventPayloadFile(githubEventPayloadFile));
     if (eventNotification) {
         notifyTeams(eventNotification);

--- a/src/resources/notification.json
+++ b/src/resources/notification.json
@@ -1,7 +1,7 @@
 {
   "@type": "MessageCard",
   "@context": "http://schema.org/extensions",
-  "themeColor": "1853DB",
+  "themeColor": "{THEME_COLOR}}",
   "summary": "Notification from Github actions",
   "sections": [
     {

--- a/test/parseEventPayloadOnPush.spec.ts
+++ b/test/parseEventPayloadOnPush.spec.ts
@@ -20,7 +20,7 @@ describe('Event payload on push', () => {
     });
 
     it('should include the expected pusher.email value', () => {
-        expect(parsed_schema.pusher.email).to.eql("54802933+eleni-salamani@users.noreply.github.com");
+        expect(parsed_schema.pusher.email).to.eql("54802933+eleni-salamani@users.noreply.github.con");
     });
 
     it('should include the expected pusher.name value', () => {

--- a/test/parseEventPayloadOnPush.spec.ts
+++ b/test/parseEventPayloadOnPush.spec.ts
@@ -20,7 +20,7 @@ describe('Event payload on push', () => {
     });
 
     it('should include the expected pusher.email value', () => {
-        expect(parsed_schema.pusher.email).to.eql("54802933+eleni-salamani@users.noreply.github.con");
+        expect(parsed_schema.pusher.email).to.eql("54802933+eleni-salamani@users.noreply.github.com");
     });
 
     it('should include the expected pusher.name value', () => {


### PR DESCRIPTION
This is a follow-up to the custom action added in the previous PR.
One thing I missed was modify the displayed color based on the job status (as is the case with the notifications sent from postman monitors directly).
Additionally I did some minor refactoring, like move the constants to a separate file.